### PR TITLE
Fix installer footguns + obsolete Firefox download (Sprint 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local tooling / scratch artifacts (not part of the project)
+.kilo/
+firefox_files.txt
+
+# Accidental nested clone of this repo (see install.sh: clones into a temp dir now)
+/rpi_tablet_os/

--- a/SPRINT.md
+++ b/SPRINT.md
@@ -1,0 +1,57 @@
+# RPi Tablet OS — Sprint Board
+
+Lightweight, version-controlled board (GitHub Project board requires a token
+scope we don't have). Move issues between columns by editing this file in the
+PR that does the work. One sprint ≈ one focused PR.
+
+**Workflow**
+1. Pick the top item from **To Do** of the active sprint.
+2. Branch off `master`: `git checkout -b fix/<issue>-<slug>`.
+3. Implement + verify; reference `Closes #<n>` in the PR description.
+4. Move the card here from **To Do** → **In Progress** → **Review** → **Done**.
+5. Work happens on the `cynarAI/rpi_tablet_os` fork; PRs target `tobykurien:master`.
+
+---
+
+## Board
+
+| Backlog | To Do (Sprint 1) | In Progress | Review | Done |
+|---|---|---|---|---|
+| #3 #4 (Sprint 2) | — | — | #8 #9 #10 #11 #12 | — |
+| #6 #7 (Sprint 3) | | | | |
+| #5 (Sprint 4) | | | | |
+
+---
+
+## Sprints
+
+### Sprint 1 — Harden the installer (bugs) — *IN REVIEW*
+**Goal:** the one-shot installer and helper scripts run without obvious footguns.
+- [x] #8 — `rm -rf rpi_tablet_os` → clone into a `mktemp -d` workdir
+- [x] #9 — `dpkg -i install …` → `dpkg -i …` (stray `install` word)
+- [x] #10 — Firefox: drop obsolete Ubuntu FTP URL, install from RPi OS repos
+- [x] #11 — Firefox: remove hardcoded `18.04.2_armhf.deb` version
+- [x] #12 — Firefox: fix inverted `if [ -e ]` "not found" check (now apt-based)
+
+### Sprint 2 — Debian trixie compatibility + docs
+**Goal:** clean install on current Raspberry Pi OS (Debian trixie/bookworm).
+- [ ] #3 — Replace removed packages (`libgles2-mesa`, `libqt4-dev`) with current
+      equivalents; handle touchegg multiarch; make apt step resilient.
+- [ ] #4 — README: troubleshooting section (touchegg multiarch, force-install).
+
+### Sprint 3 — Tablet UX enhancements
+**Goal:** nicer out-of-the-box tablet experience.
+- [ ] #6 — Improve onboard on-screen keyboard config for tablet UI.
+- [ ] #7 — Software screen-brightness control.
+
+### Sprint 4 — Quality & testing
+**Goal:** prevent regressions in the gesture/install setup.
+- [ ] #5 — Automated tests for touch-gesture configuration.
+
+---
+
+## Definition of Done
+- Code/script change committed on a feature branch and merged via PR.
+- PR references and closes the issue.
+- Scripts pass `sh -n` (syntax) and a manual smoke check where feasible.
+- Board updated (card moved to **Done**).

--- a/fs/home/pi/firefox_install.sh
+++ b/fs/home/pi/firefox_install.sh
@@ -1,16 +1,21 @@
 #!/bin/sh
-URL=ftp://ports.ubuntu.com/ubuntu-ports/pool/main/f/firefox/
-curl "$URL" > firefox_files.txt
-LATEST_BUILD=`cat firefox_files.txt|grep 18.04.2_armhf.deb|tail -n 1|awk '{print $9}'`
+# Install Firefox on Raspberry Pi OS (Debian-based).
+#
+# The old approach downloaded a hardcoded Ubuntu armhf .deb from
+# ftp://ports.ubuntu.com which (a) targeted the wrong distro and (b) pinned an
+# obsolete version (18.04.2). Raspberry Pi OS ships Firefox in its own repos, so
+# we just install from apt and fall back to firefox-esr when needed.
 
-if [ -e $LATEST_BUILD ]
- then
-   echo "Unable to find latest build"
-   exit 1
+set -e
+
+if sudo apt install -y firefox; then
+  PKG=firefox
+elif sudo apt install -y firefox-esr; then
+  PKG=firefox-esr
+else
+  echo "Unable to install Firefox from the system repositories." >&2
+  exit 1
 fi
 
-curl "$URL$LATEST_BUILD" > $LATEST_BUILD
-
-sudo dpkg -i $LATEST_BUILD || exit 1
-
-echo "Firefox installed. Open about:config and set layers.acceleration.force-enabled to true to enable hardware acceleration."
+echo "$PKG installed."
+echo "If hardware acceleration is needed, open about:config and set layers.acceleration.force-enabled to true."

--- a/install.sh
+++ b/install.sh
@@ -7,6 +7,7 @@ sudo apt remove -y bluealsa
 
 # clone into a fresh temp dir so we never rm -rf something in the cwd
 WORKDIR=$(mktemp -d)
+trap 'rm -rf "$WORKDIR"' EXIT
 git clone https://github.com/tobykurien/rpi_tablet_os.git "$WORKDIR/rpi_tablet_os"
 cd "$WORKDIR/rpi_tablet_os/fs"
 sudo cp -r * /

--- a/install.sh
+++ b/install.sh
@@ -5,15 +5,16 @@ sudo apt full-upgrade
 sudo apt install -y onboard at-spi2-core git libgles2-mesa libgles2-mesa-dev xorg-dev bluetooth bluez blueman pulseaudio libqt4-dev libx11-6 libxtst-dev libgrail6 dconf-cli
 sudo apt remove -y bluealsa
 
-rm -rf rpi_tablet_os
-git clone https://github.com/tobykurien/rpi_tablet_os.git rpi_tablet_os
-cd rpi_tablet_os/fs
+# clone into a fresh temp dir so we never rm -rf something in the cwd
+WORKDIR=$(mktemp -d)
+git clone https://github.com/tobykurien/rpi_tablet_os.git "$WORKDIR/rpi_tablet_os"
+cd "$WORKDIR/rpi_tablet_os/fs"
 sudo cp -r * /
 
 # fix ownership of files in pi home directory
 sudo chown -R pi:pi /home/pi
 
-sudo dpkg -i install /home/pi/touchegg_*.deb
+sudo dpkg -i /home/pi/touchegg_*.deb
 
 dconf load /org/onboard/ < ~/onboard.dconf
 


### PR DESCRIPTION
## Sprint 1 — Harden the installer (bugs)

Fixes the concrete installer bugs from the backlog.

### Changes
- **install.sh** — clone into a `mktemp -d` workdir instead of `rm -rf rpi_tablet_os` in the cwd (dangerous from the wrong directory). Closes #8
- **install.sh** — drop the stray `install` argument in `dpkg -i install /home/pi/touchegg_*.deb` → `dpkg -i …`. Closes #9
- **fs/home/pi/firefox_install.sh** — rewrite the obsolete downloader. The old script fetched a hardcoded Ubuntu armhf `.deb` (18.04.2) from `ftp://ports.ubuntu.com` (wrong distro, pinned version) and had an inverted `if [ -e ]` "not found" check. Raspberry Pi OS ships Firefox in its repos, so install via `apt` with a `firefox-esr` fallback. Closes #10, #11, #12

### Also
- Adds **SPRINT.md** — lightweight in-repo sprint board (PM workflow).
- Adds **.gitignore** for local tooling/scratch artifacts.

### Verification
- `sh -n install.sh` ✅
- `sh -n fs/home/pi/firefox_install.sh` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)