### PR TITLE
Static test suite for gesture configuration (Sprint 4)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,11 @@
+name: tests
+on: [push, pull_request]
+jobs:
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: sh tests/run.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,43 @@
+# Tests
+
+Static checks that run without touch hardware. Run them all with:
+
+```sh
+sh tests/run.sh
+```
+
+To run them automatically on every push and pull request, add a GitHub Actions
+workflow at `.github/workflows/tests.yml`:
+
+```yaml
+name: tests
+on: [push, pull_request]
+jobs:
+  static-checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.x"
+      - run: sh tests/run.sh
+```
+
+## What is covered
+
+- **`test_gesture_config.py`** — parses the shipped
+  `fs/home/pi/.config/touchegg/touchegg.conf` and asserts it is well-formed XML
+  and that every gesture documented in the README is present and mapped to the
+  expected action (right-click, maximize/minimize, fullscreen, tab/app
+  switching, close window). This keeps the gesture config and the docs from
+  drifting apart. Uses only the Python standard library.
+- **shell syntax** — `sh -n` on the shipped shell scripts (`install.sh`,
+  `touchegg.sh`, `firefox_install.sh`, `brightness.sh`).
+
+## What is *not* covered, and why
+
+Actually *simulating* multi-touch gestures (e.g. via `xdotool` or
+`libinput test`) needs a running X session and a real (or emulated) touch
+device, which isn't reproducible in CI. Those end-to-end checks remain a manual,
+on-device step. The static suite catches the failure mode that actually occurs
+in practice: a malformed or incomplete `touchegg.conf`.

--- a/tests/run.sh
+++ b/tests/run.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+# Test runner for rpi_tablet_os.
+#
+# Runs the static checks that don't need touch hardware:
+#   - touchegg gesture config validation (test_gesture_config.py)
+#   - `sh -n` syntax check of the shipped shell scripts
+#
+# Usage: sh tests/run.sh   (or ./tests/run.sh)
+
+set -e
+
+HERE=$(cd "$(dirname "$0")" && pwd)
+ROOT=$(cd "$HERE/.." && pwd)
+
+rc=0
+
+echo "== touchegg gesture config =="
+python3 "$HERE/test_gesture_config.py" || rc=1
+
+echo
+echo "== shell script syntax (sh -n) =="
+for f in \
+  "$ROOT/install.sh" \
+  "$ROOT/fs/home/pi/touchegg.sh" \
+  "$ROOT/fs/home/pi/firefox_install.sh" \
+  "$ROOT/fs/home/pi/brightness.sh"
+do
+  if [ -f "$f" ]; then
+    if sh -n "$f" 2>/dev/null; then
+      echo "  ok   - ${f#$ROOT/}"
+    else
+      echo "  FAIL - ${f#$ROOT/}"
+      rc=1
+    fi
+  fi
+done
+
+echo
+if [ "$rc" -eq 0 ]; then
+  echo "All checks passed."
+else
+  echo "Some checks failed."
+fi
+exit "$rc"

--- a/tests/test_gesture_config.py
+++ b/tests/test_gesture_config.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Static validation of the shipped touchegg gesture configuration.
+
+Real multi-touch gestures can only be exercised on hardware with a running X
+session (the issue's xdotool / libinput-test idea), which is not reproducible in
+CI. This suite instead guards the part that actually breaks in practice: the
+`touchegg.conf` that ships in this repo. It checks that the file is well-formed
+XML and that every gesture documented in the README is present and mapped to the
+expected action, so the config and the docs can't silently drift apart.
+
+Run via `tests/run.sh` or directly: `python3 tests/test_gesture_config.py`.
+Exit code is non-zero if any check fails.
+"""
+
+import os
+import sys
+import xml.etree.ElementTree as ET
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONF = os.path.join(
+    REPO_ROOT, "fs", "home", "pi", ".config", "touchegg", "touchegg.conf"
+)
+
+# (type, fingers, direction, action_type, {child_tag: expected_text})
+# Mirrors the gestures documented in README.md "Usage".
+EXPECTED = [
+    ("TAP", "2", None, "MOUSE_CLICK", {"button": "3"}),
+    ("SWIPE", "3", "UP", "MAXIMIZE_RESTORE_WINDOW", {}),
+    ("SWIPE", "3", "DOWN", "MINIMIZE_WINDOW", {}),
+    ("SWIPE", "3", "LEFT", "SEND_KEYS", {"modifiers": "Control_L", "keys": "Tab"}),
+    ("SWIPE", "3", "RIGHT", "SEND_KEYS", {"modifiers": "Control_L+Shift_L", "keys": "Tab"}),
+    ("PINCH", "3", "IN", "CLOSE_WINDOW", {}),
+    ("TAP", "3", None, "SEND_KEYS", {"keys": "F11"}),
+    ("SWIPE", "4", "LEFT", "SEND_KEYS", {"modifiers": "Alt_L+Shift_L", "keys": "Tab"}),
+    ("SWIPE", "4", "RIGHT", "SEND_KEYS", {"modifiers": "Alt_L", "keys": "Tab"}),
+]
+
+passed = 0
+failed = 0
+
+
+def check(ok, msg):
+    global passed, failed
+    if ok:
+        passed += 1
+        print(f"  ok   - {msg}")
+    else:
+        failed += 1
+        print(f"  FAIL - {msg}")
+
+
+def describe(gtype, fingers, direction):
+    d = f" {direction}" if direction else ""
+    return f"{fingers}-finger {gtype}{d}"
+
+
+def find_gesture(root, gtype, fingers, direction):
+    for g in root.iter("gesture"):
+        if g.get("type") != gtype or g.get("fingers") != fingers:
+            continue
+        if direction is not None and g.get("direction") != direction:
+            continue
+        if direction is None and g.get("direction") is not None:
+            continue
+        return g
+    return None
+
+
+def main():
+    print(f"touchegg config: {CONF}")
+    if not os.path.isfile(CONF):
+        print(f"  FAIL - config file not found")
+        return 1
+
+    try:
+        tree = ET.parse(CONF)
+    except ET.ParseError as exc:
+        print(f"  FAIL - config is not well-formed XML: {exc}")
+        return 1
+    print("  ok   - config is well-formed XML")
+
+    root = tree.getroot()
+
+    for gtype, fingers, direction, action_type, children in EXPECTED:
+        label = describe(gtype, fingers, direction)
+        g = find_gesture(root, gtype, fingers, direction)
+        if g is None:
+            check(False, f"{label}: gesture is defined")
+            continue
+        check(True, f"{label}: gesture is defined")
+
+        action = g.find("action")
+        check(
+            action is not None and action.get("type") == action_type,
+            f"{label}: action is {action_type}",
+        )
+        if action is None:
+            continue
+        for tag, want in children.items():
+            el = action.find(tag)
+            got = el.text if el is not None else None
+            check(got == want, f"{label}: <{tag}> is {want!r} (got {got!r})")
+
+    print(f"\n{passed} passed, {failed} failed")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Sprint 4 — Quality & testing (Closes #5)

The issue suggested simulating gestures with `xdotool` / `libinput-test`. That needs a real (or emulated) touch device and a running X session and isn't reproducible in CI, so this adds the **static** checks that catch the failure mode that actually happens in practice — a malformed or incomplete `touchegg.conf`.

### What's added
- **`tests/test_gesture_config.py`** — parses the shipped `touchegg.conf`, asserts it's well-formed XML, and verifies every gesture documented in the README is present and mapped to the expected action (right-click, maximize/minimize, fullscreen, Ctrl-Tab / Alt-Tab switching, close window). Standard library only. Doubles as a README↔config consistency guard.
- **`tests/run.sh`** — runs the config test + `sh -n` on the shipped shell scripts.
- **`tests/README.md`** — documents coverage, the hardware-only end-to-end gap, and a ready-to-paste GitHub Actions workflow.

### Verification
```
28 passed, 0 failed
All checks passed.
```

> **CI note:** a `.github/workflows/tests.yml` is included verbatim in `tests/README.md` rather than committed here, because the fork's push token lacks the `workflow` scope. It can be added via the GitHub web UI or after `gh auth refresh -s workflow`.

> Touches only new `tests/` files; independent of #13/#14/#15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)